### PR TITLE
Run inets in stand_alone mode

### DIFF
--- a/src/exometer_prometheus_httpd.erl
+++ b/src/exometer_prometheus_httpd.erl
@@ -18,7 +18,7 @@ start(Opts) ->
                         {server_name, "prometheus"},
                         {document_root, code:priv_dir(exometer_prometheus)},
                         {server_root, code:priv_dir(exometer_prometheus)}
-                    ], inets).
+                    ], stand_alone).
 
 do(Req) ->
     Method = Req#mod.method,
@@ -37,4 +37,4 @@ do(Req) ->
             RespHeaders = [{code, 404}, {content_length, ContentLength}],
             {break, [{response, {response, RespHeaders, [Payload]}}]}
     end.
-            
+


### PR DESCRIPTION
Run http endpoint in standalone mode that links its process with caller. That allows reporter to be restarted by exometer_reporter when it dies.